### PR TITLE
Null check for nameLabel. Fixed #5

### DIFF
--- a/xenstats.go
+++ b/xenstats.go
@@ -239,6 +239,17 @@ func (s Xenstats) createPoolMetrics() (metrics []*prometheus.GaugeVec, err error
 	for _, elem := range hosts {
 		nameLabel, err := s.xend.GetSpecificValue("pool.get_name_label", elem.Ref)
 
+		if err != nil {
+			return metrics, fmt.Errorf("XEN Api Error: %v", err)
+		}
+
+		if nameLabel == nil {
+			nameLabel, err = s.xend.GetSpecificValue("pool.get_uuid", elem.Ref)
+			if err != nil {
+				return metrics, fmt.Errorf("XEN Api Error: %v", err)
+			}
+		}
+
 		ha_enabled, err := s.xend.GetSpecificValue("pool.get_ha_enabled", elem.Ref)
 		if err != nil {
 			return metrics, fmt.Errorf("XEN Api Error: %v", err)


### PR DESCRIPTION
I have test that in my ENV the xenserver's poll `label_name` is null invoked by xapi. 
Owing to this, the `nameLabel` is nil not a string, and crashed the thread:
```
ERRO[0000] Encountered an API error: Failure [MESSAGE_REMOVED] 
2017/08/03 10:42:28 Xen api error in creating host memory metrics: XEN Api Error: API Error: [MESSAGE_REMOVED]
panic: interface conversion: interface {} is nil, not string
goroutine 1 [running]:
main.Xenstats.createPoolMetrics(0xc42014e300, 0xc4200a6c00, 0xc4200bbe48, 0x1, 0x1, 0xabb3c0, 0xc420153fd0)
	/home/kallen/PROJS/xenstats_exporter/xenstats.go:247 +0x14df
main.(*Exporter).collect(0xc4200a6ba0)
	/home/kallen/PROJS/xenstats_exporter/collector.go:68 +0x15c
main.NewExporter(0xc420152420, 0xc, 0xc420152460, 0x4, 0xc420152480, 0x9, 0x0)
	/home/kallen/PROJS/xenstats_exporter/collector.go:37 +0xc8
main.main()
	/home/kallen/PROJS/xenstats_exporter/main.go:45 +0xf0
```
So, I checked it and replace it by pool's `UUID` while it is nil.